### PR TITLE
Fix: random patterns when using scissor with recent sokol-shdc versions

### DIFF
--- a/src/nanovg_sokol/nanovg_sokol.h
+++ b/src/nanovg_sokol/nanovg_sokol.h
@@ -213,7 +213,7 @@ void main(void) {
     float scissor = scissorMask(fpos);
 
     if (scissor == 0) {
-        return;
+        discard;
     }
 
     if (type == 0) {    // Gradient


### PR DESCRIPTION
Older versions of sokol-shdc compiled the early `return` in main() of the fragment shader into `discard` while newer version keep the `return`. A screenshot using the GLCORE shader is attached.

This is with sokol commit `d134baeaecfc082deebdd9c9eafd6b8127e926af` from **2025-10-10** and shdc commit `a06f19929ff8f9824ec6dd87c21329b1f205809e` from **2025-09-27**.

I also updated `nanovg_sokol.h` to these versions before I recognized the pull request from @lukexi. If you like, I can make a separate pull request for the updated sokol version, including this fix and the compiled shaders.

<img width="1253" height="743" alt="nanovg_sokol_scissor" src="https://github.com/user-attachments/assets/6770d2a5-22b8-4fc7-9af6-320e3949f273" />
