### PR TITLE
Fix: make SG_DRAW macro more robust

### DIFF
--- a/src/nanovg_sokol/nanovg_sokol.h
+++ b/src/nanovg_sokol/nanovg_sokol.h
@@ -7149,7 +7149,10 @@ static unsigned int sgnvg__nearestPow2(unsigned int num)
 #ifdef SGNVG_DEBUG_LOG
 #define SGNVG_EXTLOG(...)   printf("- " __VA_ARGS__);
 #define SGNVG_INTLOG(...)   printf("  - " __VA_ARGS__);
-#define SG_DRAW(b, n, i) printf("  -> sg_draw(base_element: %d, num_elements: %d, num_instances: %d)\n", b, n, i); sg_draw(b, n, i);
+#define SG_DRAW(b, n, i) do { \
+    printf("  -> sg_draw(base_element: %d, num_elements: %d, num_instances: %d)\n", b, n, i); \
+    sg_draw(b, n, i); \
+  } while (0)
 #else
 #define SGNVG_EXTLOG(...)
 #define SGNVG_INTLOG(...)


### PR DESCRIPTION
Sorry to bug you, again. I'm currently working with nanovg_sokol.h and may stumble across one or the other issue.

If you enable `SGNVG_DEBUG_LOG` the `SG_DRAW()` macro is expanded into two statements. This leads to undefined behaviour in `sgnvg__fill()`:
```
    for (i = 0; i < npaths; i++)
        SG_DRAW(paths[i].fillOffset, paths[i].fillCount, 1);
```
In the loop, only the `printf()` from the macro is executed and the `sg_draw()` is executed after the loop with `i = npaths`. It runs when compiling with `clang` but with `gcc` it triggered the assertion that the argument `base_element` should be >= 0 because `i` had a random negative value.

The patch makes the macro more robust so that it can be used in different syntactic contexts.